### PR TITLE
add: UDP

### DIFF
--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -134,6 +134,7 @@ GameObject:
   - component: {fileID: 1057999246}
   - component: {fileID: 1057999245}
   - component: {fileID: 1057999248}
+  - component: {fileID: 1057999250}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -227,6 +228,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7fbdfdf6defc345ed8310d596196ae60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1057999250
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1057999244}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5ebabe7d56ad407ab68332fda01f480, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  port: 5005
 --- !u!1 &1232989431
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/UDP.meta
+++ b/Assets/UDP.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c2844d0ec40d4326b3770b6a03bcf31
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UDP/Receive_Data.cs
+++ b/Assets/UDP/Receive_Data.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Collections;
+using System.Collections.Generic;
+using System;
+
+public class Receive_Data : MonoBehaviour
+{
+    // ポート番号
+    [SerializeField] private int port = 5005;
+
+    // UDPクライアント
+    private UdpClient server;
+
+    // 受信したデータを保持するキュー
+    private readonly Queue<string> receivedDataQueue = new();
+
+    private bool first = true;
+
+    void Start()
+    {
+        // サーバーのIPアドレスを取得
+        IPAddress ipAddress = IPAddress.Any;
+
+        // UDPクライアントの作成
+        server = new UdpClient(port);
+        IPEndPoint endPoint = new(ipAddress, port);
+
+        Debug.Log("UDPサーバーを起動しました");
+
+        // データ受信の非同期処理を開始
+        server.BeginReceive(ReceiveData, endPoint);
+
+        // データ処理を非同期的に行うコルーチンを開始
+        StartCoroutine(ProcessData());
+    }
+
+    // データ受信時の処理
+    private void ReceiveData(IAsyncResult result)
+    {
+        // データと送信元のIPアドレスを取得
+        IPEndPoint endPoint = new(IPAddress.Any, port);
+        byte[] receivedBytes = server.EndReceive(result, ref endPoint);
+        string receivedMessage = Encoding.ASCII.GetString(receivedBytes);
+
+        Debug.Log("受信したデータ: " + receivedMessage);
+
+        // 受信したデータをキューに追加
+        lock (receivedDataQueue)
+        {
+            receivedDataQueue.Enqueue(receivedMessage);
+        }
+
+        // 再度データ受信の準備
+        server.BeginReceive(ReceiveData, endPoint);
+    }
+
+    // データ処理のコルーチン
+    private IEnumerator ProcessData()
+    {
+        while (true)
+        {
+            string data = null;
+
+            // 受信データがあるか確認
+            lock (receivedDataQueue)
+            {
+                if (receivedDataQueue.Count > 0)
+                {
+                    data = receivedDataQueue.Dequeue();
+                }
+            }
+
+            // 受信データがあれば処理
+            if (data != null)
+            {
+                // 受信データを処理
+                Debug.Log("受信データを処理: " + data);
+            }
+
+            // 1フレーム待機
+            yield return null;
+        }
+    }
+
+    void OnDestroy()
+    {
+        // UDPサーバーの終了
+        server?.Close();
+    }
+}

--- a/Assets/UDP/Receive_Data.cs.meta
+++ b/Assets/UDP/Receive_Data.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5ebabe7d56ad407ab68332fda01f480
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
python側のプログラムから、手のx座標をUDP通信で受け取る

変更を加えた箇所
・TitleSceneのMainCameraにReceive_Data.csをアタッチ。
　ポート番号はインスペクターウィンドウで変更可能。ただし、python側のプログラムと合わせる必要があります。
　現在のポート番号: 5050

新規作成プログラム
Assets -> UDP
・Receive_Data.cs
　pythonから、手のx座標をUDP通信で受け取るプログラム
　x座標を、0 ~ 100 の範囲の整数値で受信する。より細かく、0 ~ 1000とかにもできると思うので、相談してください。
　できる限りUnity側の都合のいいようなデータになるように調整します。

　このx座標のデータをUnity側で解釈して、木の先端部分のx座標に適応されることを想定しています。

Receive_Data の動作
1. TitleScene読み込み時に、デバッグログにUDP起動メッセージを表示：UDPサーバーを起動しました
2. pthonからデータを受信したら、デバッグログに数値を表示：受信したデータ: *ここに受信した数値*
