### PR TITLE
ゲーム内の木の傾きに変換

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2735,7 +2735,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aa9c5b182e8e843df8421f1a0c1d6d82, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  grow_speed: 0.2
+  grow_speed: 0.1
   is_key: 0
   cube_obj: {fileID: 2986815384033673886, guid: e8dfaf162af59407487da7270d35d5d4, type: 3}
 --- !u!114 &1854217193

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1317,6 +1317,51 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &608628653
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 608628655}
+  - component: {fileID: 608628654}
+  m_Layer: 0
+  m_Name: UDP
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &608628654
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 608628653}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5ebabe7d56ad407ab68332fda01f480, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  port: 5005
+--- !u!4 &608628655
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 608628653}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &674174704
 Mesh:
   m_ObjectHideFlags: 0
@@ -3066,3 +3111,4 @@ SceneRoots:
   - {fileID: 6393040361260416928}
   - {fileID: 1637029183}
   - {fileID: 771669314}
+  - {fileID: 608628655}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -2702,7 +2702,7 @@ GameObject:
   - component: {fileID: 1854217192}
   - component: {fileID: 1854217193}
   m_Layer: 0
-  m_Name: GameObject (1)
+  m_Name: Set_segment
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2735,9 +2735,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: aa9c5b182e8e843df8421f1a0c1d6d82, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  grow_speed: 0.2
+  is_key: 0
   cube_obj: {fileID: 2986815384033673886, guid: e8dfaf162af59407487da7270d35d5d4, type: 3}
-  branch_obj: {fileID: 550971444049018917, guid: 6440e7de773864f72b189d6d91fa4ed3, type: 3}
-  branch_obj2: {fileID: 550971444049018917, guid: 0cb6be25fac3f40d2ab768c97eb620f0, type: 3}
 --- !u!114 &1854217193
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/UDP/Receive_Data.cs
+++ b/Assets/UDP/Receive_Data.cs
@@ -23,6 +23,8 @@ public class Receive_Data : MonoBehaviour
 
     void Start()
     {
+        x_zahyo = 50;
+
         // サーバーのIPアドレスを取得
         IPAddress ipAddress = IPAddress.Any;
 

--- a/Assets/UDP/Receive_Data.cs
+++ b/Assets/UDP/Receive_Data.cs
@@ -19,6 +19,8 @@ public class Receive_Data : MonoBehaviour
 
     private bool first = true;
 
+    public static int x_zahyo = 50;
+
     void Start()
     {
         // サーバーのIPアドレスを取得
@@ -28,7 +30,7 @@ public class Receive_Data : MonoBehaviour
         server = new UdpClient(port);
         IPEndPoint endPoint = new(ipAddress, port);
 
-        Debug.Log("UDPサーバーを起動しました");
+        //Debug.Log("UDPサーバーを起動しました");
 
         // データ受信の非同期処理を開始
         server.BeginReceive(ReceiveData, endPoint);
@@ -45,7 +47,7 @@ public class Receive_Data : MonoBehaviour
         byte[] receivedBytes = server.EndReceive(result, ref endPoint);
         string receivedMessage = Encoding.ASCII.GetString(receivedBytes);
 
-        Debug.Log("受信したデータ: " + receivedMessage);
+        //Debug.Log("受信したデータ: " + receivedMessage);
 
         // 受信したデータをキューに追加
         lock (receivedDataQueue)
@@ -77,7 +79,10 @@ public class Receive_Data : MonoBehaviour
             if (data != null)
             {
                 // 受信データを処理
-                Debug.Log("受信データを処理: " + data);
+                //Debug.Log("受信データを処理: " + data);
+
+                x_zahyo = int.Parse(data);
+                Debug.Log(x_zahyo);
             }
 
             // 1フレーム待機

--- a/Assets/nobiru_cube.cs
+++ b/Assets/nobiru_cube.cs
@@ -30,6 +30,9 @@ public class nobiru_cube : MonoBehaviour
         // 成長が最大高さに達していない場合
         if (currentHeight < growthLimit)
         {
+
+            
+
             // 十字キー入力による成長方向の制御
             if (Input.GetKey(KeyCode.RightArrow))
             {
@@ -74,6 +77,21 @@ public class nobiru_cube : MonoBehaviour
             }
 
 
+            growthDirection = (Receive_Data.x_zahyo - 50) * 0.2f;
+            if(growthDirection > 0)
+            {
+                if (set_segment.top_position.x > right_limit)
+                {
+                    growthDirection = 0.0f;
+                }
+            }
+            else
+            {
+                if (set_segment.top_position.x < left_limit)
+                {
+                    growthDirection = 0.0f;
+                }
+            }
 
             // Y軸方向に頂点を移動
             for (int i = 0; i < vertices.Length; i++)
@@ -93,12 +111,12 @@ public class nobiru_cube : MonoBehaviour
                 // X方向の移動方向を調整
                 if (growthDirection > 0.0f)
                 {
-                    vertices[i].x += xOffset * Time.deltaTime;
+                    vertices[i].x += xOffset * Time.deltaTime * growthDirection;
 
                 }
                 else if (growthDirection < 0.0f)
                 {
-                    vertices[i].x -= xOffset * Time.deltaTime;
+                    vertices[i].x -= xOffset * Time.deltaTime * -1 * growthDirection;
                 }
                 
                 vertices[i].y += growthSpeed * Time.deltaTime;

--- a/Assets/nobiru_cube.cs
+++ b/Assets/nobiru_cube.cs
@@ -16,9 +16,11 @@ public class nobiru_cube : MonoBehaviour
 
     [SerializeField] float left_limit = -2.0f;
     [SerializeField] float right_limit = 2.0f;
+    [SerializeField] bool is_key = false;
 
     void Start()
     {
+        is_key = set_segment.is_key_pub;
         mesh = GetComponent<MeshFilter>().mesh;
         vertices = mesh.vertices;
         
@@ -31,65 +33,69 @@ public class nobiru_cube : MonoBehaviour
         if (currentHeight < growthLimit)
         {
 
-            
-
-            // 十字キー入力による成長方向の制御
-            if (Input.GetKey(KeyCode.RightArrow))
+            if (is_key == true)
             {
 
-                if (set_segment.top_position.x < right_limit)
+                // 十字キー入力による成長方向の制御
+                if (Input.GetKey(KeyCode.RightArrow))
                 {
-                    growthDirection = 1.0f;
+
+                    if (set_segment.top_position.x < right_limit)
+                    {
+                        growthDirection = 1.0f;
+                    }
+                    else
+                    {
+                        growthDirection = 0.0f;
+                    }
+
+
+                }
+                else if (Input.GetKey(KeyCode.LeftArrow))
+                {
+
+                    if (set_segment.top_position.x > left_limit)
+                    {
+                        growthDirection = -1.0f;
+                    }
+                    else
+                    {
+                        growthDirection = 0.0f;
+                    }
+
                 }
                 else
                 {
-                    growthDirection = 0.0f;
+                    //growthDirection = 0.0f;
+
+                    if (set_segment.top_position.x > right_limit)
+                    {
+                        growthDirection = 0.0f;
+                    }
+
+                    if (set_segment.top_position.x < left_limit)
+                    {
+                        growthDirection = 0.0f;
+                    }
                 }
-                
 
             }
-            else if (Input.GetKey(KeyCode.LeftArrow))
+            else
             {
-
-                if (set_segment.top_position.x > left_limit)
+                growthDirection = (Receive_Data.x_zahyo - 50) * set_segment.grow_speed_pub;
+                if (growthDirection > 0)
                 {
-                    growthDirection = -1.0f;
+                    if (set_segment.top_position.x > right_limit)
+                    {
+                        growthDirection = 0.0f;
+                    }
                 }
                 else
                 {
-                    growthDirection = 0.0f;
-                }
-                
-            }
-            else
-            {
-                //growthDirection = 0.0f;
-
-                if (set_segment.top_position.x > right_limit)
-                {
-                    growthDirection = 0.0f;
-                }
-
-                if (set_segment.top_position.x < left_limit)
-                {
-                    growthDirection = 0.0f;
-                }
-            }
-
-
-            growthDirection = (Receive_Data.x_zahyo - 50) * 0.2f;
-            if(growthDirection > 0)
-            {
-                if (set_segment.top_position.x > right_limit)
-                {
-                    growthDirection = 0.0f;
-                }
-            }
-            else
-            {
-                if (set_segment.top_position.x < left_limit)
-                {
-                    growthDirection = 0.0f;
+                    if (set_segment.top_position.x < left_limit)
+                    {
+                        growthDirection = 0.0f;
+                    }
                 }
             }
 

--- a/Assets/set_segment.cs
+++ b/Assets/set_segment.cs
@@ -3,10 +3,15 @@ using System.Collections;
 
 public class set_segment : MonoBehaviour
 {
+    [SerializeField] float grow_speed = 0.2f;
+    public static float grow_speed_pub;
+
+    [SerializeField] bool is_key = false;
+    public static bool is_key_pub;
 
     public GameObject cube_obj;
-    public GameObject branch_obj;
-    public GameObject branch_obj2;
+    //public GameObject branch_obj;
+    //public GameObject branch_obj2;
     float add_value = 0.29f;
 
     public static Vector3 top_position;
@@ -24,6 +29,8 @@ public class set_segment : MonoBehaviour
 
     void Start()
     {
+        grow_speed_pub = grow_speed;
+        is_key_pub = is_key;
         obj = Instantiate(cube_obj, new Vector3(0,0,0), Quaternion.identity);
 
         // コルーチンを開始
@@ -54,13 +61,13 @@ public class set_segment : MonoBehaviour
             branch_count++;
             if(branch_count %5 == 0)
             {
-                Vector3 desiredRotation = new Vector3(-90f, 0f, 0f);
+                //Vector3 desiredRotation = new Vector3(-90f, 0f, 0f);
                 //obj2 = Instantiate(branch_obj, new Vector3(next_position.x - 0.5f, transform.position.y + y_value - 0.2f, transform.position.z-0.5f), Quaternion.identity);
                 // Quaternion.Euler を使って回転角度を指定
                 //obj2.transform.rotation = Quaternion.Euler(desiredRotation);
 
 
-                desiredRotation = new Vector3(90f, 0f, 0f);
+                //desiredRotation = new Vector3(90f, 0f, 0f);
                 //obj3 = Instantiate(branch_obj2, new Vector3(next_position.x - 0.5f, transform.position.y + y_value - 0.2f, transform.position.z+0.5f), Quaternion.identity);
                 // Quaternion.Euler を使って回転角度を指定
                 //obj3.transform.rotation = Quaternion.Euler(desiredRotation);

--- a/Assets/set_segment.cs
+++ b/Assets/set_segment.cs
@@ -29,6 +29,7 @@ public class set_segment : MonoBehaviour
 
     void Start()
     {
+        
         grow_speed_pub = grow_speed;
         is_key_pub = is_key;
         obj = Instantiate(cube_obj, new Vector3(0,0,0), Quaternion.identity);

--- a/ProjectSettings/Packages/com.unity.probuilder/Settings.json
+++ b/ProjectSettings/Packages/com.unity.probuilder/Settings.json
@@ -139,7 +139,7 @@
             {
                 "type": "UnityEngine.Vector3, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",
                 "key": "ShapeBuilder.LastSize",
-                "value": "{\"m_Value\":{\"x\":11.169036865234375,\"y\":12.145441055297852,\"z\":10.11381721496582}}"
+                "value": "{\"m_Value\":{\"x\":0.08647305518388748,\"y\":0.10203695297241211,\"z\":0.14808043837547303}}"
             },
             {
                 "type": "UnityEngine.Quaternion, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null",


### PR DESCRIPTION
pythonから送られてきたデータをもとに、木の頂点を操作する #6
へのプルリクです

動作は　SampleSceneで確認できます
変更点
空のオブジェクト「UDP」を作り UDP受信スクリプトをアタッチした
木の一部分を成長させるクラス nobiru_cube に変換処理を書いた
set_segmentクラスに調整項目を追加した

## このクラスを使う人向けの説明
木の左右動作をキーボードで行いたい場合は　is_keyのチェックボックスにチェック
そうでないならチェックを外してください

Grow_speed [float 型]　デフォルト値 0.2は
木が左右に行くのが速いと思ったら下げる
遅いと思ったら値を上げてください

<img width="932" alt="スクリーンショット 2024-07-03 15 47 41" src="https://github.com/CC-Circle/Yoga_Earth/assets/133644847/3909aabc-e3fe-4166-a203-9f53b492d505">
