### PR TITLE
Update Receive_Data.cs

### DIFF
--- a/Assets/UDP/Receive_Data.cs
+++ b/Assets/UDP/Receive_Data.cs
@@ -82,8 +82,15 @@ public class Receive_Data : MonoBehaviour
             {
                 // 受信データを処理
                 //Debug.Log("受信データを処理: " + data);
-
-                x_zahyo = int.Parse(data);
+                if (x_zahyo != -1)
+                {
+                    x_zahyo = int.Parse(data);
+                }
+                else
+                {
+                    // 送られてきたデータが-1の場合は、プレイヤーが正しく木のポーズをとっていない。
+                    // そのため、今回のプルリクでは、-1の場合は何もしないようにしています。
+                }
                 Debug.Log(x_zahyo);
             }
 


### PR DESCRIPTION
UDPでpythonから-1を受け取った場合は、プレイヤーが木のポーズを正しく取れていないということ。

そこで、このプルリクでは、pythonから-1が送られてきた場合は、x_zahyoの値を更新しないこととする。