### PR TITLE
If not posing not growing

### DIFF
--- a/Assets/UDP/Receive_Data.cs
+++ b/Assets/UDP/Receive_Data.cs
@@ -82,8 +82,17 @@ public class Receive_Data : MonoBehaviour
             {
                 // 受信データを処理
                 //Debug.Log("受信データを処理: " + data);
+                if (x_zahyo != -1)
+                {
+                    x_zahyo = int.Parse(data);
+                }
+                else
+                {
+                    //x_zahyo = int.Parse(data);
+                    // 送られてきたデータが-1の場合は、プレイヤーが正しく木のポーズをとっていない。
+                    // そのため、今回のプルリクでは、-1の場合は何もしないようにしています。
 
-                x_zahyo = int.Parse(data);
+                }
                 Debug.Log(x_zahyo);
             }
 

--- a/Assets/UDP/Receive_Data.cs
+++ b/Assets/UDP/Receive_Data.cs
@@ -88,7 +88,7 @@ public class Receive_Data : MonoBehaviour
                 }
                 else
                 {
-                    //x_zahyo = int.Parse(data);
+                    x_zahyo = int.Parse(data);
                     // 送られてきたデータが-1の場合は、プレイヤーが正しく木のポーズをとっていない。
                     // そのため、今回のプルリクでは、-1の場合は何もしないようにしています。
 

--- a/Assets/nobiru_cube.cs
+++ b/Assets/nobiru_cube.cs
@@ -18,121 +18,141 @@ public class nobiru_cube : MonoBehaviour
     [SerializeField] float right_limit = 2.0f;
     [SerializeField] bool is_key = false;
 
+    public bool is_limit = false;
+
     void Start()
     {
         is_key = set_segment.is_key_pub;
         mesh = GetComponent<MeshFilter>().mesh;
         vertices = mesh.vertices;
-        
+
+        is_limit = false;
         growthLimit = growadd;
     }
 
     void Update()
     {
+        if (Receive_Data.x_zahyo == -1)
+        {
+            growthDirection = 0;
+        }
+
         // 成長が最大高さに達していない場合
         if (currentHeight < growthLimit)
         {
 
-            if (is_key == true)
+            if (Receive_Data.x_zahyo != -1 & is_key == false)
             {
 
-                // 十字キー入力による成長方向の制御
-                if (Input.GetKey(KeyCode.RightArrow))
+                if (is_key == true)
                 {
 
-                    if (set_segment.top_position.x < right_limit)
+                    // 十字キー入力による成長方向の制御
+                    if (Input.GetKey(KeyCode.RightArrow))
                     {
-                        growthDirection = 1.0f;
+
+                        if (set_segment.top_position.x < right_limit)
+                        {
+                            growthDirection = 1.0f;
+                        }
+                        else
+                        {
+                            growthDirection = 0.0f;
+                        }
+
+
+                    }
+                    else if (Input.GetKey(KeyCode.LeftArrow))
+                    {
+
+                        if (set_segment.top_position.x > left_limit)
+                        {
+                            growthDirection = -1.0f;
+                        }
+                        else
+                        {
+                            growthDirection = 0.0f;
+                        }
+
                     }
                     else
                     {
-                        growthDirection = 0.0f;
-                    }
+                        //growthDirection = 0.0f;
 
+                        if (set_segment.top_position.x > right_limit)
+                        {
+                            growthDirection = 0.0f;
+                        }
 
-                }
-                else if (Input.GetKey(KeyCode.LeftArrow))
-                {
-
-                    if (set_segment.top_position.x > left_limit)
-                    {
-                        growthDirection = -1.0f;
-                    }
-                    else
-                    {
-                        growthDirection = 0.0f;
+                        if (set_segment.top_position.x < left_limit)
+                        {
+                            growthDirection = 0.0f;
+                        }
                     }
 
                 }
                 else
                 {
-                    //growthDirection = 0.0f;
+                    growthDirection = (Receive_Data.x_zahyo - 50) * set_segment.grow_speed_pub;
 
-                    if (set_segment.top_position.x > right_limit)
+
+
+                    if (growthDirection > 0)
                     {
-                        growthDirection = 0.0f;
+                        if (set_segment.top_position.x > right_limit)
+                        {
+                            growthDirection = 0.0f;
+                        }
                     }
-
-                    if (set_segment.top_position.x < left_limit)
+                    else
                     {
-                        growthDirection = 0.0f;
-                    }
-                }
-
-            }
-            else
-            {
-                growthDirection = (Receive_Data.x_zahyo - 50) * set_segment.grow_speed_pub;
-                if (growthDirection > 0)
-                {
-                    if (set_segment.top_position.x > right_limit)
-                    {
-                        growthDirection = 0.0f;
+                        if (set_segment.top_position.x < left_limit)
+                        {
+                            growthDirection = 0.0f;
+                        }
                     }
                 }
-                else
+
+                // Y軸方向に頂点を移動
+                for (int i = 0; i < vertices.Length; i++)
                 {
-                    if (set_segment.top_position.x < left_limit)
+                    // Y座標が現在の高さより低い頂点はそのまま
+                    if (vertices[i].y <= currentHeight)
                     {
-                        growthDirection = 0.0f;
+                        continue;
                     }
+
+                    // Y座標が現在の高さより高い頂点は、上に移動し、X方向にも移動
+                    float yOffset = vertices[i].y - currentHeight;
+                    float xOffset = yOffset * Mathf.Tan(growthAngle * Mathf.Deg2Rad);
+
+
+
+                    // X方向の移動方向を調整
+                    if (growthDirection > 0.0f)
+                    {
+                        vertices[i].x += xOffset * Time.deltaTime * growthDirection;
+
+                    }
+                    else if (growthDirection < 0.0f)
+                    {
+                        vertices[i].x -= xOffset * Time.deltaTime * -1 * growthDirection;
+                    }
+
+                    vertices[i].y += growthSpeed * Time.deltaTime;
                 }
-            }
 
-            // Y軸方向に頂点を移動
-            for (int i = 0; i < vertices.Length; i++)
-            {
-                // Y座標が現在の高さより低い頂点はそのまま
-                if (vertices[i].y <= currentHeight)
-                {
-                    continue;
-                }
+                // 現在の高さを更新
+                currentHeight += growthSpeed * Time.deltaTime;
 
-                // Y座標が現在の高さより高い頂点は、上に移動し、X方向にも移動
-                float yOffset = vertices[i].y - currentHeight;
-                float xOffset = yOffset * Mathf.Tan(growthAngle * Mathf.Deg2Rad);
-                
-
-
-                // X方向の移動方向を調整
-                if (growthDirection > 0.0f)
-                {
-                    vertices[i].x += xOffset * Time.deltaTime * growthDirection;
-
-                }
-                else if (growthDirection < 0.0f)
-                {
-                    vertices[i].x -= xOffset * Time.deltaTime * -1 * growthDirection;
-                }
-                
-                vertices[i].y += growthSpeed * Time.deltaTime;
+                // メッシュの更新
+                mesh.vertices = vertices;
             }
 
-            // 現在の高さを更新
-            currentHeight += growthSpeed * Time.deltaTime;
-
-            // メッシュの更新
-            mesh.vertices = vertices;
+        }
+        else
+        {
+            is_limit = true;
         }
     }
 }

--- a/Assets/nobiru_cube.cs
+++ b/Assets/nobiru_cube.cs
@@ -41,7 +41,7 @@ public class nobiru_cube : MonoBehaviour
         if (currentHeight < growthLimit)
         {
 
-            if (Receive_Data.x_zahyo != -1 & is_key == false)
+            if (Receive_Data.x_zahyo != -1)
             {
 
                 if (is_key == true)

--- a/Assets/set_segment.cs
+++ b/Assets/set_segment.cs
@@ -27,12 +27,15 @@ public class set_segment : MonoBehaviour
 
     int branch_count = 0;
 
+    nobiru_cube nobiru_class;
+
     void Start()
     {
-        
+
         grow_speed_pub = grow_speed;
         is_key_pub = is_key;
-        obj = Instantiate(cube_obj, new Vector3(0,0,0), Quaternion.identity);
+        obj = Instantiate(cube_obj, new Vector3(0, 0, 0), Quaternion.identity);
+        nobiru_class = obj.GetComponent<nobiru_cube>();
 
         // コルーチンを開始
         StartCoroutine(RepeatedCoroutine());
@@ -48,18 +51,31 @@ public class set_segment : MonoBehaviour
         float y_value = 0;
         while (true)
         {
-            
+
             // ここに秒ごとに実行する処理を書く
-            yield return new WaitForSeconds(0.5f);  // 1秒待機
+            if (nobiru_class.is_limit == false)
+            {
+                yield return null;
+            }
+            else
+            {
+                yield return new WaitForSeconds(0.05f);  // チャタリング
 
-            next_position = GetTopPosition(obj);
-            Debug.Log(next_position);
+                next_position = GetTopPosition(obj);
+                Debug.Log(next_position);
 
 
-            y_value += add_value;
-            obj = Instantiate(cube_obj, new Vector3(next_position.x+0.475f, transform.position.y + y_value, transform.position.z), Quaternion.identity);
+                y_value += add_value;
+                obj = Instantiate(cube_obj, new Vector3(next_position.x + 0.475f, transform.position.y + y_value, transform.position.z), Quaternion.identity);
+                nobiru_class = obj.GetComponent<nobiru_cube>();
+                branch_count++;
 
-            branch_count++;
+
+
+            }
+
+
+            /*
             if(branch_count %5 == 0)
             {
                 //Vector3 desiredRotation = new Vector3(-90f, 0f, 0f);
@@ -75,6 +91,7 @@ public class set_segment : MonoBehaviour
 
 
             }
+            */
         }
     }
 


### PR DESCRIPTION
## 変更

Receive_Data.cs　　　pythonが-1のとき「受け取らない」だと困ってしまうので-1も使用する方に変更
nobiru_cube.cs　　　　受け取る値に対応して木が伸びない　機能を追加
set_segment.cs　　　　木が伸び切るまでは新しい木の片を生成しないように変更

## これによって実現されること
プレイヤーが正しく木のポーズを取れているときだけ、木が成長するように

## 動作
動作は一度見てもらったかと思います

動作確認の際
正常に動作しない時があったかと思いますが最新のコミットでは修正されています