### PR TITLE
タイトルシーンで一定時間木のポーズをとったら、SampleSceneに移動

### DIFF
--- a/Assets/Move_Scene/Title_Scene.cs
+++ b/Assets/Move_Scene/Title_Scene.cs
@@ -5,9 +5,12 @@ using UnityEngine;
 public class Title_Scene : MonoBehaviour
 {
     // Start is called before the first frame update
+    private int pose_cnt = 0;
+    [SerializeField] private int GameStart;
     void Start()
     {
         Debug.Log("Title Scene");
+        pose_cnt = 0;
     }
 
     // Update is called once per frame
@@ -18,6 +21,21 @@ public class Title_Scene : MonoBehaviour
             Debug.Log("Space key was pressed.");
             // Load the game scene
             UnityEngine.SceneManagement.SceneManager.LoadScene("SampleScene");
+        }
+
+        if (Receive_Data.x_zahyo != -1)
+        {
+            pose_cnt++;
+        }
+
+        if (pose_cnt > GameStart)
+        {
+            UnityEngine.SceneManagement.SceneManager.LoadScene("SampleScene");
+        }
+
+        if (Receive_Data.x_zahyo == -1)
+        {
+            pose_cnt = -500;
         }
     }
 }

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1977,7 +1977,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fc8736349219d426cac781682603c13c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  goal: 40
+  goal: 3
 --- !u!43 &1025905377
 Mesh:
   m_ObjectHideFlags: 0
@@ -2995,7 +2995,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   grow_speed: 0.1
-  is_key: 1
+  is_key: 0
   cube_obj: {fileID: 2986815384033673886, guid: e8dfaf162af59407487da7270d35d5d4, type: 3}
 --- !u!114 &1854217193
 MonoBehaviour:

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -228,6 +228,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7fbdfdf6defc345ed8310d596196ae60, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  GameStart: 5000
 --- !u!114 &1057999250
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
タイトルシーンで一定時間木のポーズをとったら、SampleSceneに移動
python側の変更はありません。Unity側だけ


変更したプログラム
TitleSceneのMainCameraにアタッチされたTitle_Scene.csを変更
インスペクターウィンドウでint GameStartの値によって、TitleSceneで取らないといけない木のポーズの時間が変わる。
